### PR TITLE
Use OnUnitActiveSec

### DIFF
--- a/clients/go/hack/apiban-iptables.timer
+++ b/clients/go/hack/apiban-iptables.timer
@@ -2,7 +2,7 @@
 Description=APIBan IPTables service schedule
 
 [Timer]
-OnActiveSec=300
+OnUnitActiveSec=300
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
After talking with Seán in the matrix room, we believe OnUnitActiveSec is actually a better match to have the apiban-iptables-client process start back up.
Once in place, you can use `systemctl list-timers` to see the next run time and the previous run time.

https://www.freedesktop.org/software/systemd/man/systemd.timer.html